### PR TITLE
Attenti mobile delete enrollments by type

### DIFF
--- a/voiceit2/src/main/AndroidManifest.xml
+++ b/voiceit2/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
             android:value="face"/>
 
         <activity android:name=".InstructionalVideoView"
+            android:exported="true"
             android:label="@string/app_name">
 
             <intent-filter>
@@ -35,6 +36,7 @@
         </activity>
 
         <activity android:name=".VideoEnrollmentView"
+            android:exported="true"
             android:label="@string/app_name"
             android:keepScreenOn="true">
 
@@ -44,6 +46,7 @@
         </activity>
 
         <activity android:name=".VideoVerificationView"
+            android:exported="true"
             android:label="@string/app_name">
 
             <intent-filter>
@@ -52,6 +55,7 @@
         </activity>
 
         <activity android:name=".FaceEnrollmentView"
+            android:exported="true"
             android:label="@string/app_name">
 
             <intent-filter>
@@ -60,6 +64,7 @@
         </activity>
 
         <activity android:name=".FaceVerificationView"
+            android:exported="true"
             android:label="@string/app_name">
 
             <intent-filter>
@@ -68,6 +73,7 @@
         </activity>
 
         <activity android:name=".VoiceEnrollmentView"
+            android:exported="true"
             android:label="@string/app_name">
 
             <intent-filter>
@@ -76,6 +82,7 @@
         </activity>
 
         <activity android:name=".VoiceVerificationView"
+            android:exported="true"
             android:label="@string/app_name">
 
             <intent-filter>
@@ -84,6 +91,7 @@
         </activity>
 
         <activity android:name=".VoiceIdentificationView"
+            android:exported="true"
             android:label="@string/app_name">
 
             <intent-filter>

--- a/voiceit2/src/main/java/com/voiceit/voiceit2/VoiceItAPI2.java
+++ b/voiceit2/src/main/java/com/voiceit/voiceit2/VoiceItAPI2.java
@@ -146,6 +146,30 @@ public class VoiceItAPI2 {
 
         client.delete(getAbsoluteUrl("/enrollments/" + userId + "/all" + "?notificationURL=" + this.notificationURL), responseHandler);
     }
+    
+    public void deleteAllVoiceEnrollments(String userId, AsyncHttpResponseHandler responseHandler) {
+        if(!userIdFormatted(userId)) {
+            responseHandler.sendFailureMessage(200, null, buildJSONFormatMessage().toString().getBytes(), new Throwable());
+            return;
+        }
+        client.delete(getAbsoluteUrl("/enrollments/" + userId + "/voice"), responseHandler);
+    }
+
+    public void deleteAllFaceEnrollments(String userId, AsyncHttpResponseHandler responseHandler) {
+        if(!userIdFormatted(userId)) {
+            responseHandler.sendFailureMessage(200, null, buildJSONFormatMessage().toString().getBytes(), new Throwable());
+            return;
+        }
+        client.delete(getAbsoluteUrl("/enrollments/" + userId + "/face"), responseHandler);
+    }
+
+    public void deleteAllVideoEnrollments(String userId, AsyncHttpResponseHandler responseHandler) {
+        if(!userIdFormatted(userId)) {
+            responseHandler.sendFailureMessage(200, null, buildJSONFormatMessage().toString().getBytes(), new Throwable());
+            return;
+        }
+        client.delete(getAbsoluteUrl("/enrollments/" + userId + "/video"), responseHandler);
+    }
 
     public void getAllVoiceEnrollments(String userId, AsyncHttpResponseHandler responseHandler) {
         if(!userIdFormatted(userId)) {


### PR DESCRIPTION
* Added exported=true to manifest - needed for API 31 support.
* Added methods for deleting all enrollments by type